### PR TITLE
Documentation/blog post: tutorial for downloading IPUMS extract #27

### DIFF
--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -225,7 +225,7 @@ open("cps_extract.json", "w") do io
 end
 ```
 
-Either form — hand-written `.json` or Julia-serialized — produces the same file on disk, which is what we'll feed to `extract_submit` next.
+Either hand-written `.json` or Julia-serialized produces the same file on disk, which is what we'll feed to `extract_submit` next.
 
 !!! note "Sharing or revising an extract"
     Because an IPUMS.jl extract definition is just a JSON file, *sharing* a definition
@@ -345,3 +345,53 @@ colmetadata(df, :INCTOT, "category_labels")  # value→label mappings for missin
 
 Extract-level metadata (citation, conditions of use, project, extract date, notes) is attached at the DataFrame level via `DataFrames.metadata`.
 
+## Putting it all together
+
+The full microdata workflow, end to end:
+
+```julia
+using IPUMS, JSON3, CodecZlib
+
+# 1. Define the extract
+extract = Dict(
+    "description"   => "CPS ASEC 2018-2019: demographics and income",
+    "dataStructure" => Dict("rectangular" => Dict("on" => "P")),
+    "dataFormat"    => "fixed_width",
+    "samples"       => Dict("cps2018_03s" => Dict(), "cps2019_03s" => Dict()),
+    "variables"     => Dict(
+        "AGE"      => Dict(),
+        "SEX"      => Dict(),
+        "STATEFIP" => Dict(),
+        "INCTOT"   => Dict("dataQualityFlags" => true),
+        "ASECWT"   => Dict(),
+    ),
+)
+open(io -> JSON3.pretty(io, extract), "cps_extract.json", "w")
+
+# 2. Client
+api = IPUMSAPI("https://api.ipums.org/", Dict("Authorization" => ENV["IPUMS_API_KEY"]))
+
+# 3. Submit and wait
+res = extract_submit(api, "cps", "cps_extract.json")
+metadata, _, _ = extract_info(api, res.number, "cps")
+while metadata["status"] ∉ ("completed", "failed", "canceled")
+    sleep(30)
+    metadata, _, _ = extract_info(api, res.number, "cps")
+end
+
+# 4. Download
+extract_download(api, res.number, "cps"; output_path = "downloads/")
+
+# 5. Decompress and load
+dat_gz = filter(endswith(".dat.gz"), readdir("downloads"; join=true))[1]
+xml    = filter(endswith(".xml"),    readdir("downloads"; join=true))[1]
+dat    = replace(dat_gz, r"\.gz$" => "")
+open(GzipDecompressorStream, dat_gz) do io
+    write(dat, read(io))
+end
+
+ddi = parse_ddi(xml)
+df  = load_ipums_extract(ddi, dat)
+```
+
+`df` is a `DataFrame` carrying the extract's variables plus DDI-derived column and table metadata, ready for analysis.

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -297,3 +297,51 @@ extract_download(api, res.number, "cps"; output_path = "downloads/")
 
 For microdata (USA, CPS, IPUMS International), `codebook` produces the DDI `.xml` and `table_data` produces a compressed `.dat.gz`. `gis_data` has no effect since microdata extracts don't carry shapefiles. The next section parses these two files into a `DataFrame`.
 
+## Reading microdata into a DataFrame
+
+Two functions cover the read step: `parse_ddi` parses the DDI XML codebook into a `DDIInfo` struct, and `load_ipums_extract` uses that struct to read the fixed-width data file into a `DataFrame`.
+
+The data file arrives as `.dat.gz` and needs to be decompressed first. CodecZlib handles it without leaving Julia:
+
+```julia
+using CodecZlib
+
+open(GzipDecompressorStream, "downloads/cps_00142.dat.gz") do io
+    write("downloads/cps_00142.dat", read(io))
+end
+```
+
+Then parse and load:
+
+```julia
+ddi = parse_ddi("downloads/cps_00142.xml")
+df  = load_ipums_extract(ddi, "downloads/cps_00142.dat")
+```
+
+Using the CPS fixture that ships with the package:
+
+```julia
+ddi = parse_ddi("test/testdata/cps_00157.xml")
+df  = load_ipums_extract(ddi, "test/testdata/cps_00157.dat")
+```
+
+```
+3×8 DataFrame
+ Row │ YEAR   SERIAL  MONTH  ASECWTH  STATEFIP  PERNUM  ASECWT   INCTOT
+     │ Int64  Int64   Int64  Float64  Int64     Int64   Float64  Int64
+─────┼─────────────────────────────────────────────────────────────────────
+   1 │  1962      80      3  1475.59        55       1  1475.59       4883
+   2 │  1962      80      3  1475.59        55       2  1470.72       5800
+   3 │  1962      80      3  1475.59        55       3  1578.75  999999998
+```
+
+Variable-level metadata (label, description, category mappings, coder instructions) is attached to each column via `DataFrames.colmetadata`:
+
+```julia
+using DataFrames
+colmetadata(df, :INCTOT, "label")        # "Total personal income"
+colmetadata(df, :INCTOT, "category_labels")  # value→label mappings for missing codes
+```
+
+Extract-level metadata (citation, conditions of use, project, extract date, notes) is attached at the DataFrame level via `DataFrames.metadata`.
+

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -36,3 +36,56 @@ The rest of this tutorial uses **IPUMS CPS** as the microdata example and **IPUM
     be downloaded manually from each project's website. Once those projects gain v2 API
     support, `IPUMS.jl` should be able to reach them with no code changes on your side.
 
+## Setting up your API key
+
+To use the IPUMS API you need two things: an IPUMS account on each project you'll
+extract data from, and a personal API key.
+
+1. **Register an account** with the IPUMS project(s) you want to use. Each project has
+   its own registration page — e.g. [IPUMS CPS](https://cps.ipums.org/cps/),
+   [IPUMS USA](https://usa.ipums.org/usa/), [IPUMS International](https://international.ipums.org/international/), [IPUMS NHGIS](https://www.nhgisorg/). Registration is free; usage is governed by each project's [terms of use](https://www.ipums.org/about/terms).
+
+2. **Generate an API key** at [account.ipums.org/api_keys](https://account.ipums.org/api_keys).
+   A single key works across every IPUMS project your account is registered with. Treat it like a password — anyone with the key can submit extract requests on your behalf.
+
+### Store the key in an environment variable
+
+Hard-coding the key in a script is the easiest way to inadvertently leak it. The conventional pattern is to put it in an environment variable named `IPUMS_API_KEY` and read it from `ENV` in Julia:
+
+```bash
+# in your shell profile (.zshrc, .bashrc, etc.)
+export IPUMS_API_KEY="paste-your-key-here"
+```
+
+```julia
+julia> ENV["IPUMS_API_KEY"]
+"paste-your-key-here"
+```
+
+For a one-off session you can set it directly at the Julia REPL:
+
+```julia
+ENV["IPUMS_API_KEY"] = "paste-your-key-here"
+```
+
+!!! warning "Don't commit your API key"
+    Never paste your key into a script, notebook, or `.jl` file that you commit to version control. If you accidentally do, [revoke it](https://account.ipums.org/api_keys) and generate a new one.
+
+### Construct the API client
+
+With your key in `ENV`, build an `IPUMSAPI` client. Every subsequent call in this
+tutorial — submitting extracts, checking status, downloading files — takes this client as its first argument.
+
+```julia
+using IPUMS
+
+api = IPUMSAPI(
+    "https://api.ipums.org/",
+    Dict("Authorization" => ENV["IPUMS_API_KEY"]),
+)
+```
+
+The first argument is the API base URL (always `"https://api.ipums.org/"` for the v2 API). The second is the request headers; the IPUMS API authenticates by reading the raw key out of the `Authorization` header — there is no `Bearer ` prefix.
+
+That's all the setup. The next section assumes you have obtained an API key and stored it in the IPUMS_API_KEY environment variable. 
+

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -89,3 +89,159 @@ The first argument is the API base URL (always `"https://api.ipums.org/"` for th
 
 That's all the setup. The next section assumes you have obtained an API key and stored it in the IPUMS_API_KEY environment variable. 
 
+## Defining a microdata extract (IPUMS USA / CPS)
+
+An extract definition is a JSON document that tells the IPUMS API what samples and
+variables you want. Unlike in R, in Julia you write the JSON yourself — either by hand as a `.json` file, or by constructing a Julia `Dict` and serializing it with `JSON3`. `extract_submit` takes the path to that file.
+
+### Anatomy of a microdata extract
+
+The top-level keys for a microdata extract are:
+
+| Key | Required | What it specifies |
+|---|---|---|
+| `description` | yes | A human-readable label for your own bookkeeping |
+| `dataStructure` | yes | Whether the output is rectangular (one row per chosen unit) or hierarchical |
+| `dataFormat` | yes | File format — `"fixed_width"` for microdata |
+| `samples` | yes | Which samples (years/supplements) to draw from |
+| `variables` | yes | Which variables to include, plus per-variable options |
+
+`dataStructure` is itself an object. Rectangular layouts pick one record type via `on`
+(`"P"` for person-level, `"H"` for household-level); hierarchical layouts take no
+sub-fields:
+
+```json
+"dataStructure": { "rectangular": { "on": "P" } }
+```
+
+```json
+"dataStructure": { "hierarchical": {} }
+```
+
+`samples` and `variables` are both dictionaries keyed by the IPUMS code. Sample codes
+look like `cps2019_03s` (the CPS March 2019 ASEC supplement) or `us2019a` (IPUMS USA
+2019 ACS 1-year). You can look them up in each project's web portal — there is no API
+endpoint listing microdata samples programmatically.
+
+### A worked CPS example
+
+```json
+{
+  "description": "CPS ASEC 2018-2019: demographics and income",
+  "dataStructure": { "rectangular": { "on": "P" } },
+  "dataFormat": "fixed_width",
+  "samples": {
+    "cps2018_03s": {},
+    "cps2019_03s": {}
+  },
+  "variables": {
+    "AGE": {},
+    "SEX": {},
+    "STATEFIP": {},
+    "INCTOT": {},
+    "ASECWT": {}
+  }
+}
+```
+
+Save this as e.g. `cps_extract.json`. The next section shows how to submit it.
+
+### Weights are just variables
+
+The issue checklist for this tutorial mentions "selecting weights." In the IPUMS API
+weights are just regular variables whose values happen to encode sampling weights. The relevant ones depend on the collection:
+
+| Collection | Common weight variables |
+|---|---|
+| IPUMS USA | `PERWT` (person), `HHWT` (household) |
+| IPUMS CPS (basic monthly) | `WTFINL` (person), `HWTFINL` (household) |
+| IPUMS CPS (ASEC) | `ASECWT` (person), `ASECWTH` (household) |
+| IPUMS International | `PERWT`, `HHWT` |
+
+Add them to `variables` the same way you'd add any other variable.
+
+### Data quality flags ("quality scores")
+
+Many IPUMS variables have a companion variable that records whether the value was
+edited, imputed, or allocated by the source agency — IPUMS calls these **data quality
+flags**. To include the quality flag for a given variable, set `dataQualityFlags: true`
+on the variable entry:
+
+```json
+"variables": {
+  "INCTOT": { "dataQualityFlags": true },
+  "EDUC":   { "dataQualityFlags": true }
+}
+```
+
+Each variable with `dataQualityFlags: true` adds a companion column to the extract
+(e.g. `QINCTOT` next to `INCTOT`).
+
+### Per-variable options at a glance
+
+A few other per-variable options come up often enough to mention:
+
+- **`caseSelections`** — restrict the extract to specific category codes. The codes are
+  passed as **strings**, not integers:
+
+  ```json
+  "MARST": { "caseSelections": { "general": ["1", "2"] } }
+  ```
+
+- **`attachedCharacteristics`** — attach values from a related person to each record
+  (e.g. parents' education on each child's row):
+
+  ```json
+  "EDUC": { "attachedCharacteristics": ["mother", "father", "spouse"] }
+  ```
+
+- **`adjustMonetaryValues`** — for income variables, ask the API to convert dollars to a
+  common base year:
+
+  ```json
+  "INCTOT": { "adjustMonetaryValues": true }
+  ```
+
+A full list of per-variable options is in the
+[IPUMS API microdata reference](https://developer.ipums.org/docs/v2/workflows/create_extracts/microdata/).
+
+### Building the JSON from Julia instead of a file
+
+If you'd rather construct the extract in Julia, build a `Dict` and serialize it. Note
+that `extract_submit` always reads from a **file path on disk**, so you still need to
+write it out:
+
+```julia
+using JSON3
+
+extract = Dict(
+    "description"   => "CPS ASEC 2018-2019: demographics and income",
+    "dataStructure" => Dict("rectangular" => Dict("on" => "P")),
+    "dataFormat"    => "fixed_width",
+    "samples"       => Dict(
+        "cps2018_03s" => Dict(),
+        "cps2019_03s" => Dict(),
+    ),
+    "variables"     => Dict(
+        "AGE"      => Dict(),
+        "SEX"      => Dict(),
+        "STATEFIP" => Dict(),
+        "INCTOT"   => Dict("dataQualityFlags" => true),
+        "ASECWT"   => Dict(),
+    ),
+)
+
+open("cps_extract.json", "w") do io
+    JSON3.pretty(io, extract)
+end
+```
+
+Either form — hand-written `.json` or Julia-serialized — produces the same file on
+disk, which is what we'll feed to `extract_submit` next.
+
+!!! note "Sharing or revising an extract"
+    Because an IPUMS.jl extract definition is just a JSON file, *sharing* a definition
+    is the file itself — commit it to your repo or paste it into an email. *Revising*
+    an extract means editing the file and submitting it again, which produces a new
+    extract number. There is no `revise_extract` helper. 
+

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -265,3 +265,35 @@ end
     Microdata extracts are removed from IPUMS servers **72 hours** after completion;
     NHGIS extracts after **2 weeks**. Download promptly or you'll need to resubmit.
 
+## Listing past extracts and downloading
+
+`extract_list` returns the most recent extracts for a collection:
+
+```julia
+extract_list(api, "cps")              # 10 most recent
+extract_list(api, "cps"; extracts=50) # up to 50
+```
+
+The result is a `Vector{DataExtract}` — each element exposes `.number`, `.status`,
+`.extractDefinition`, and `.downloadLinks`.
+
+!!! note "Pagination ceiling"
+    The current implementation requests one page sized to `extracts`; requesting more
+    than ~255 will error. Tracked in the package source as a TODO.
+
+Once an extract is `completed`, download its files with `extract_download`:
+
+```julia
+extract_download(api, res.number, "cps"; output_path = "downloads/")
+```
+
+| Keyword | Default | Effect |
+|---|---|---|
+| `output_path` | `pwd()` | Directory the files land in |
+| `codebook` | `true` | Download the codebook / DDI file |
+| `table_data` | `true` | Download the data file |
+| `gis_data` | `true` | Download GIS / shapefile (NHGIS only) |
+| `codebook_name` / `table_data_name` / `gis_data_name` | `nothing` | Override the default filenames |
+
+For microdata (USA, CPS, IPUMS International), `codebook` produces the DDI `.xml` and `table_data` produces a compressed `.dat.gz`. `gis_data` has no effect since microdata extracts don't carry shapefiles. The next section parses these two files into a `DataFrame`.
+

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -1,9 +1,38 @@
-# Tutorials 
+# Introduction to the IPUMS API for Julia Users
 
+[IPUMS](https://www.ipums.org/) hosts dozens of population, health, and geospatial data collections. There are two ways to pull data out of them:
 
-## Tutorial 1
+1. **Through the IPUMS website**, by browsing samples and variables in a project's web portal, building an extract interactively, and downloading the result by hand.
+2. **Through the IPUMS API**, by defining the same extract programmatically. This is what `IPUMS.jl` does.
 
+The API approach is the right one when you want your data extract to be **reproducible** (the request lives in code, not in a forgotten browser tab), **shareable** with collaborators, or **integrated into a script** that downloads and loads the data in one go.
 
-## Tutorial 2
+This tutorial walks through the full end-to-end workflow with `IPUMS.jl`:
 
-## Tutorial 3
+- Setting up your API key and an `IPUMSAPI` client
+- Writing an extract definition (microdata and aggregate-data variants)
+- Submitting the extract, waiting for it to finish, and downloading the files
+- Reading the result into a Julia `DataFrame`
+
+It's modelled on the corresponding [ipumsr R article](https://tech.popdata.org/ipumsr/articles/ipums-api.html); where IPUMS.jl works differently from ipumsr, the relevant section calls it out.
+
+## Supported collections
+
+`IPUMS.jl` exposes the IPUMS v2 API. Not every IPUMS collection is reachable through that API yet — some are still web-only. To see which collections you can currently use from Julia, call `ipums_data_collections()`:
+
+```julia
+using IPUMS
+
+ipums_data_collections()
+```
+
+The `code_for_api` column is the short identifier you'll pass to functions like
+`extract_submit` and `extract_download`. When the column is blank, the API code is the same as the lowercased project name (`"usa"`, `"cps"`, `"nhgis"`). When it's populated (e.g. `ipumsi` for IPUMS International), use that string instead.
+
+The rest of this tutorial uses **IPUMS CPS** as the microdata example and **IPUMS NHGIS** as the aggregate-data example, but the same pattern works for IPUMS USA and IPUMS International.
+
+!!! note "Collections without API support"
+    Collections with `api_support = false` (IPUMS ATUS, DHS, NHIS, MEPS, etc.) can still
+    be downloaded manually from each project's website. Once those projects gain v2 API
+    support, `IPUMS.jl` should be able to reach them with no code changes on your side.
+

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -26,8 +26,7 @@ using IPUMS
 ipums_data_collections()
 ```
 
-The `code_for_api` column is the short identifier you'll pass to functions like
-`extract_submit` and `extract_download`. When the column is blank, the API code is the same as the lowercased project name (`"usa"`, `"cps"`, `"nhgis"`). When it's populated (e.g. `ipumsi` for IPUMS International), use that string instead.
+The `code_for_api` column is the short identifier you'll pass to functions like `extract_submit` and `extract_download`. When the column is blank, the API code is the same as the lowercased project name (`"usa"`, `"cps"`, `"nhgis"`). When it's populated (e.g. `ipumsi` for IPUMS International), use that string instead.
 
 The rest of this tutorial uses **IPUMS CPS** as the microdata example and **IPUMS NHGIS** as the aggregate-data example, but the same pattern works for IPUMS USA and IPUMS International.
 
@@ -73,8 +72,7 @@ ENV["IPUMS_API_KEY"] = "paste-your-key-here"
 
 ### Construct the API client
 
-With your key in `ENV`, build an `IPUMSAPI` client. Every subsequent call in this
-tutorial — submitting extracts, checking status, downloading files — takes this client as its first argument.
+With your key in `ENV`, build an `IPUMSAPI` client. Every subsequent call in this tutorial  takes this client as its first argument.
 
 ```julia
 using IPUMS
@@ -91,8 +89,7 @@ That's all the setup. The next section assumes you have obtained an API key and 
 
 ## Defining a microdata extract (IPUMS USA / CPS)
 
-An extract definition is a JSON document that tells the IPUMS API what samples and
-variables you want. Unlike in R, in Julia you write the JSON yourself — either by hand as a `.json` file, or by constructing a Julia `Dict` and serializing it with `JSON3`. `extract_submit` takes the path to that file.
+An extract definition is a JSON document that tells the IPUMS API what samples and variables you want. Unlike in R, in Julia you write the JSON yourself — either by hand as a `.json` file, or by constructing a Julia `Dict` and serializing it with `JSON3`. `extract_submit` takes the path to that file.
 
 ### Anatomy of a microdata extract
 
@@ -118,10 +115,7 @@ sub-fields:
 "dataStructure": { "hierarchical": {} }
 ```
 
-`samples` and `variables` are both dictionaries keyed by the IPUMS code. Sample codes
-look like `cps2019_03s` (the CPS March 2019 ASEC supplement) or `us2019a` (IPUMS USA
-2019 ACS 1-year). You can look them up in each project's web portal — there is no API
-endpoint listing microdata samples programmatically.
+`samples` and `variables` are both dictionaries keyed by the IPUMS code. Sample codes look like `cps2019_03s` (the CPS March 2019 ASEC supplement) or `us2019a` (IPUMS USA 2019 ACS 1-year). You can look them up in each project's web portal — there is no API endpoint listing microdata samples programmatically.
 
 ### A worked CPS example
 
@@ -148,8 +142,7 @@ Save this as e.g. `cps_extract.json`. The next section shows how to submit it.
 
 ### Weights are just variables
 
-The issue checklist for this tutorial mentions "selecting weights." In the IPUMS API
-weights are just regular variables whose values happen to encode sampling weights. The relevant ones depend on the collection:
+The issue checklist for this tutorial mentions "selecting weights." In the IPUMS API weights are just regular variables whose values happen to encode sampling weights. The relevant ones depend on the collection:
 
 | Collection | Common weight variables |
 |---|---|
@@ -163,9 +156,7 @@ Add them to `variables` the same way you'd add any other variable.
 ### Data quality flags ("quality scores")
 
 Many IPUMS variables have a companion variable that records whether the value was
-edited, imputed, or allocated by the source agency — IPUMS calls these **data quality
-flags**. To include the quality flag for a given variable, set `dataQualityFlags: true`
-on the variable entry:
+edited, imputed, or allocated by the source agency — IPUMS calls these **data quality flags**. To include the quality flag for a given variable, set `dataQualityFlags: true` on the variable entry:
 
 ```json
 "variables": {
@@ -207,9 +198,7 @@ A full list of per-variable options is in the
 
 ### Building the JSON from Julia instead of a file
 
-If you'd rather construct the extract in Julia, build a `Dict` and serialize it. Note
-that `extract_submit` always reads from a **file path on disk**, so you still need to
-write it out:
+If you'd rather construct the extract in Julia, build a `Dict` and serialize it. Note that `extract_submit` always reads from a **file path on disk**, so you still need to write it out:
 
 ```julia
 using JSON3
@@ -236,12 +225,43 @@ open("cps_extract.json", "w") do io
 end
 ```
 
-Either form — hand-written `.json` or Julia-serialized — produces the same file on
-disk, which is what we'll feed to `extract_submit` next.
+Either form — hand-written `.json` or Julia-serialized — produces the same file on disk, which is what we'll feed to `extract_submit` next.
 
 !!! note "Sharing or revising an extract"
     Because an IPUMS.jl extract definition is just a JSON file, *sharing* a definition
     is the file itself — commit it to your repo or paste it into an email. *Revising*
     an extract means editing the file and submitting it again, which produces a new
     extract number. There is no `revise_extract` helper. 
+
+## Submitting and waiting for completion
+
+`extract_submit` takes the JSON file path and returns a `DataExtractPostResponse` with the assigned extract number and an initial status:
+
+```julia
+res = extract_submit(api, "cps", "cps_extract.json")
+res.number   # e.g. 142
+res.status   # "queued"
+```
+
+Extracts run asynchronously on IPUMS servers. To poll, call `extract_info`, which returns a `(metadata, defn, msg)` tuple where `metadata["status"]` is the live status:
+
+```julia
+metadata, _, _ = extract_info(api, res.number, "cps")
+while metadata["status"] ∉ ("completed", "failed", "canceled")
+    sleep(30)
+    metadata, _, _ = extract_info(api, res.number, "cps")
+end
+```
+
+| Status | Meaning |
+|---|---|
+| `queued` | Accepted, not yet started |
+| `started` | Running |
+| `produced` | Files generated, finalizing |
+| `completed` | Ready to download |
+| `failed` / `canceled` | Terminal error states |
+
+!!! warning "Extracts expire"
+    Microdata extracts are removed from IPUMS servers **72 hours** after completion;
+    NHGIS extracts after **2 weeks**. Download promptly or you'll need to resubmit.
 

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -394,4 +394,20 @@ ddi = parse_ddi(xml)
 df  = load_ipums_extract(ddi, dat)
 ```
 
-`df` is a `DataFrame` carrying the extract's variables plus DDI-derived column and table metadata, ready for analysis.
+`df` is a `DataFrame` carrying the extract's variables plus DDI-derived column and table metadata, ready for analysis using your favorite Julia packages.
+
+## Limitations and roadmap
+
+`IPUMS.jl` covers the core extract loop but is younger than the R `ipumsr` package and has some gaps you'll notice if you've used the R version:
+
+- **No fluent extract-builder for microdata.** R's `define_extract_micro()` is, in
+  Julia, a hand-written JSON file (see [Defining a microdata extract](#defining-a-microdata-extract-ipums-usa-cps)).
+- **No `wait_for_extract` helper.** Polling is a manual `while` loop on `extract_info`.
+- **No `.dat.gz` auto-decompression.** `load_ipums_extract` reads `.dat`, so the gzip
+  step is on the user.
+- **Collections without API support.** ATUS, AHTUS, MTUS, DHS, PMA, MICS, NHIS, MEPS,
+  Higher Ed, and IHGIS are not yet reachable through `IPUMS.jl` (see the §1
+  collections table).
+- **`extract_list` pagination ceiling** of ~255 results.
+
+Contributions on any of these are very much welcomed. 


### PR DESCRIPTION
Closes #27 

This adds to `docs/src/tutorials.md`, which is a walkthrough of the IPUMS extract API workflow with `IPUMS.jl`, modeled on the [ipumsr R article](https://tech.popdata.org/ipumsr/articles/ipums-api.html).

**Overview:** supported collections, API key setup, defining a microdata extract in JSON (weights, data quality flags, case selections), `extract_submit`, `extract_download`, and reading the result into a `DataFrame` via `parse_ddi` + `load_ipums_extract`. Ends with a full end-to-end script and a `Limitations and roadmap` section.

**Out of scope:** the NHGIS / aggregate-data flow. Planning to open a follow-up issue.

**Note:** a few claims would benefit from a second pair of eyes, specifically the IPUMS sample codes (`cps2018_03s` / `cps2019_03s`), the `Authorization` header format, and the `colmetadata` key strings used in the reading section. Also, the reading section pulls in a new dependency (`CodecZlib`) for `.dat.gz` decompression, and I dropped the outer `# Tutorials` heading since this is the only article on the page. I'm happy to revise anything if needed. 